### PR TITLE
Investigate 502 error in AI chat

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -123,6 +123,16 @@ export async function POST(req: Request) {
     
     // Handle specific error types
     if (error instanceof Error) {
+      if (error.message.includes('API key not configured')) {
+        return NextResponse.json(
+          { 
+            error: "AI service configuration error", 
+            details: "Claude API key not configured. Please set CLAUDE_API_KEY or ANTHROPIC_API_KEY in your environment variables." 
+          },
+          { status: 500 }
+        );
+      }
+      
       if (error.message.includes('Claude API error')) {
         return NextResponse.json(
           { 
@@ -137,16 +147,6 @@ export async function POST(req: Request) {
         return NextResponse.json(
           { error: "Conversation not found or access denied" },
           { status: 404 }
-        );
-      }
-      
-      if (error.message.includes('API key not configured')) {
-        return NextResponse.json(
-          { 
-            error: "AI service configuration error", 
-            details: "API key not configured. Contact the site administrator." 
-          },
-          { status: 500 }
         );
       }
     }


### PR DESCRIPTION
Refine AI chat error handling to return 500 for missing API keys and provide clearer messages.

Previously, a missing Claude API key could result in a generic 502 error or a less informative 500. This change ensures that the specific "API key not configured" error is caught earlier, returning a more accurate 500 status code with explicit instructions on which environment variables to set (`CLAUDE_API_KEY` or `ANTHROPIC_API_KEY`).